### PR TITLE
Pre-clone websockify to prevent novnc from doing it on startup.

### DIFF
--- a/tasks/novnc.yml
+++ b/tasks/novnc.yml
@@ -17,6 +17,9 @@
 - name: Clone novnc
   git: repo=https://github.com/kanaka/noVNC.git dest={{ novnc_install_dir }}
 
+- name: Clone websockify
+  git: repo=https://github.com/kanaka/websockify dest={{ novnc_install_dir }}/websockify
+
 - name: Create ~/.vnc dir
   file: path=~/.vnc state=directory
   sudo_user: "{{ default_user }}"


### PR DESCRIPTION
This fixes an issue where novnc will attempt to clone websockify on startup, which makes the build non-replicable. Also avoids permission issues on startup.
