### PR TITLE
Change R apt repo to use rstudio official

### DIFF
--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -9,7 +9,7 @@
 - name: Add line to apt sources.list for R version upgrade
   lineinfile:
     dest=/etc/apt/sources.list
-    line="deb http://cran.cnr.Berkeley.edu/bin/linux/ubuntu trusty/"
+    line="deb http://cran.rstudio.com/bin/linux/ubuntu trusty/"
 
 - name: Add Cloudera's apt key
   apt_key: url=http://archive.cloudera.com/cdh5/ubuntu/trusty/amd64/cdh/archive.key


### PR DESCRIPTION
The existing repo throws the following error:
    amazon-ebs: TASK: [galaxyprojectdotorg.cloudman-image | Install new r-base 3.2.2 or above] ***
    amazon-ebs: failed: [localhost] => {"failed": true}
    amazon-ebs: stderr: E: Version '3.2_' for 'r-base' was not found
    amazon-ebs:
    amazon-ebs: stdout: Reading package lists...
    amazon-ebs: Building dependency tree...
    amazon-ebs: Reading state information...
    amazon-ebs:
    amazon-ebs: msg: '/usr/bin/apt-get -y -o "Dpkg::Options::=--force-confdef" -o "Dpkg::Options::=--force-confold"   install 'r-base=3.2_'' failed: E: Version '3.2*' for 'r-base' was not found
